### PR TITLE
chore/9: add workflow to publish the package to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,17 @@
+name: Publish package on crates.io
+
+on:
+  release:
+    types: ["created"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Publish package
+      run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
Resolves #9 