### PR TITLE
feat/21: create help command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,8 +87,8 @@ fn usage() -> ! {
   std::process::exit(0)
 }
 
-fn operation_of_string(arg: String) -> Operation {
-  match arg.as_str() {
+fn operation_of_string(arg: &str) -> Operation {
+  match arg {
     "h" | "help" => Operation::Help,
     _ => {
       eprintln!("ERROR: invalid argument \"{}\"", arg);
@@ -104,7 +104,7 @@ fn parse_cli(argument: String) -> Operation {
       .filter(|char| char != &'-')
       .collect::<String>();
 
-    operation_of_string(arg_name)
+    operation_of_string(&arg_name)
   } else {
     Operation::Version(argument)
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,10 +20,6 @@ fn main() {
     Err(e) => error_exit(&format!("failed to read Cargo.toml file: {}", e)),
   };
 
-  if let Operation::Help = operation {
-    usage()
-  }
-
   let new_version = match operation {
     Operation::Version(v) => match v.as_str() {
       "patch" => cargo_v::VersionLabel::Patch,
@@ -31,7 +27,7 @@ fn main() {
       "major" => cargo_v::VersionLabel::Major,
       version => cargo_v::VersionLabel::NumericVersion(String::from(version)),
     },
-    _ => unreachable!(),
+    Operation::Help => usage(),
   };
 
   let cargo_toml_updated =


### PR DESCRIPTION
This PR enables passing a help flag to cargo-v. It can be `-h` or `--help`.  🎉 

e.g.
```console
cargo v -h
```
```console
cargo v --help
```
I tried to keep this very simple, if we need more options, maybe we can have a more advanced argument parser. 

Resolves #21 